### PR TITLE
Fix error google auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "laravel/socialite": "3.1.*",
+        "laravel/socialite": "3.4.*",
         "socialiteproviders/discord": "2.0.*",
         "socialiteproviders/twitch": "5.0.*",
         "socialiteproviders/mixer": "1.0.*",


### PR DESCRIPTION
Fix error Google Plus

`Client error: `GET https://www.googleapis.com/plus/v1/people/me?prettyPrint=false` resulted in a `403 Forbidden` response:
{
  "error": {
    "code": 403,
    "message": "Legacy People API has not been used in project 848046987143 before or it (truncated...)
in /var/www/html/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php on line 113`